### PR TITLE
Fix apiVersion and kind are missing in jaeger-operator generate output

### DIFF
--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -106,6 +106,10 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) runtime.Object {
 	cronjobsVersion := viper.GetString(v1.FlagCronJobsVersion)
 	if cronjobsVersion == v1.FlagCronJobsVersionBatchV1Beta1 {
 		cj := &batchv1beta1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectmeta,
 			Spec: batchv1beta1.CronJobSpec{
 				Schedule:                   jaeger.Spec.Storage.EsIndexCleaner.Schedule,
@@ -118,6 +122,10 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) runtime.Object {
 		o = cj
 	} else {
 		cj := &batchv1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectmeta,
 			Spec: batchv1.CronJobSpec{
 				Schedule:                   jaeger.Spec.Storage.EsIndexCleaner.Schedule,

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -57,6 +57,10 @@ func rollover(jaeger *v1.Jaeger) runtime.Object {
 	cronjobsVersion := viper.GetString(v1.FlagCronJobsVersion)
 	if cronjobsVersion == v1.FlagCronJobsVersionBatchV1Beta1 {
 		cj := &batchv1beta1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1beta1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
@@ -70,6 +74,10 @@ func rollover(jaeger *v1.Jaeger) runtime.Object {
 		o = cj
 	} else {
 		cj := &batchv1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1.ForbidConcurrent,
@@ -158,6 +166,10 @@ func lookback(jaeger *v1.Jaeger) runtime.Object {
 	cronjobsVersion := viper.GetString(v1.FlagCronJobsVersion)
 	if cronjobsVersion == v1.FlagCronJobsVersionBatchV1Beta1 {
 		cj := &batchv1beta1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1beta1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
@@ -174,6 +186,10 @@ func lookback(jaeger *v1.Jaeger) runtime.Object {
 		o = cj
 	} else {
 		cj := &batchv1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1.ForbidConcurrent,

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -116,6 +116,10 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) runtime.Object {
 	cronjobsVersion := viper.GetString(v1.FlagCronJobsVersion)
 	if cronjobsVersion == v1.FlagCronJobsVersionBatchV1Beta1 {
 		cj := &batchv1beta1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1beta1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
@@ -130,6 +134,10 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) runtime.Object {
 		o = cj
 	} else {
 		cj := &batchv1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CronJob",
+				APIVersion: cronjobsVersion,
+			},
 			ObjectMeta: objectMeta,
 			Spec: batchv1.CronJobSpec{
 				ConcurrencyPolicy:          batchv1.ForbidConcurrent,

--- a/pkg/deployment/autoscale.go
+++ b/pkg/deployment/autoscale.go
@@ -69,6 +69,10 @@ func autoscalers(component component) []runtime.Object {
 
 	if autoscalingVersion == v1.FlagAutoscalingVersionV2Beta2 {
 		autoscaler := autoscalingv2beta2.HorizontalPodAutoscaler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "HorizontalPodAutoscaler",
+				APIVersion: autoscalingVersion,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        component.name(),
 				Namespace:   jaeger.Namespace,
@@ -119,6 +123,10 @@ func autoscalers(component component) []runtime.Object {
 		result = append(result, &autoscaler)
 	} else {
 		autoscaler := autoscalingv2.HorizontalPodAutoscaler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "HorizontalPodAutoscaler",
+				APIVersion: autoscalingVersion,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        component.name(),
 				Namespace:   jaeger.Namespace,


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Resolves 2137

## Short description of the changes
- Added missing ApiVersion and Kind for HPA and Cronjobs